### PR TITLE
Make standard library loadable from host apps

### DIFF
--- a/src/bin/interpreter.rs
+++ b/src/bin/interpreter.rs
@@ -52,6 +52,7 @@ fn main() {
                     print!("ERROR: Failed to load prelude: {}\n", error);
                     exit(1);
                 })
+                .with_default_modules()
                 .run(&mut (), path.into(), Box::new(file));
         }
         None => {
@@ -64,6 +65,7 @@ fn main() {
                     print!("ERROR: Failed to load prelude: {}\n", error);
                     exit(1);
                 })
+                .with_default_modules()
                 .run(&mut (), "<stdin>".into(), stdin);
         }
     }

--- a/src/bin/tester.rs
+++ b/src/bin/tester.rs
@@ -67,6 +67,7 @@ fn main() {
                 print!("ERROR: Failed to load prelude: {}\n", error);
                 exit(1);
             })
+            .with_default_modules()
             .run(&mut (), path.into(), Box::new(file));
 
         results.push((success, path.to_owned()));

--- a/src/context.rs
+++ b/src/context.rs
@@ -65,6 +65,7 @@ pub enum Error {
         candidates: Signatures,
         scope:      String,
     },
+    ModuleNotFound(String),
     Io(io::Error),
     Parser(parser::Error),
     Type(TypeError),
@@ -77,6 +78,7 @@ impl Error {
             Error::DefineFunction(_)       => (),
             Error::Failure                 => (),
             Error::FunctionNotFound { .. } => (),
+            Error::ModuleNotFound(_)       => (),
 
             Error::Parser(error) => error.spans(spans),
             Error::Type(error)   => error.spans(spans),
@@ -181,6 +183,9 @@ impl fmt::Display for Error {
             }
             Error::FunctionNotFound { name, .. } => {
                 write!(f, "No matching function found: `{}`", name)
+            }
+            Error::ModuleNotFound(name) => {
+                write!(f, "Module not found: {}", name)
             }
             Error::Io(error) => {
                 write!(f, "Error loading stream: {}", error)


### PR DESCRIPTION
So far, `load` would would load a file, but files weren't shipped with
Kari and only available in the repository. With this change, the
standard library is included in the binary, and `load` will only load
previously registered modules.